### PR TITLE
Flexible landscape orientation

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:name="Main"
         android:exported="true"
         android:launchMode="singleTask"
-        android:screenOrientation="landscape">
+        android:screenOrientation="userLandscape">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
@@ -41,11 +41,11 @@
 
     <activity
         android:name="SettingsActivity"
-        android:screenOrientation="landscape" />
+        android:screenOrientation="userLandscape" />
 
     <activity
         android:name="HelpActivity"
-        android:screenOrientation="landscape" />
+        android:screenOrientation="userLandscape" />
 
   </application>
 


### PR DESCRIPTION
I replaced `landscape` with `userLandscape` in the orientation config, which allows users to use the normal/reversed landscape orientation and lock to one of them if they want.